### PR TITLE
Fixes for rpdk build

### DIFF
--- a/aws-amplifyuibuilder-component/pom.xml
+++ b/aws-amplifyuibuilder-component/pom.xml
@@ -24,6 +24,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
+            <version>[2.0.0,3.0.0)</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/aws-amplifyuibuilder-form/pom.xml
+++ b/aws-amplifyuibuilder-form/pom.xml
@@ -24,6 +24,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
+            <version>[2.0.0,3.0.0)</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/aws-amplifyuibuilder-theme/pom.xml
+++ b/aws-amplifyuibuilder-theme/pom.xml
@@ -24,6 +24,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
+            <version>[2.0.0,3.0.0)</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
The RPDX Java plugin needs to have a version explicitly specified or the build fails.
